### PR TITLE
Update version-sync to 0.9.3 and trim some deps from Cargo.lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,13 @@ include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
 bstr = { version = "0.2.4", default-features = false }
 
 [dev-dependencies]
+
 # Check that crate versions are properly updated in documentation and code when
 # bumping the version.
-version-sync = "0.9, >= 0.9.2"
+[dev-dependencies.version-sync]
+version = "0.9.3"
+default-features = false
+features = ["markdown_deps_updated", "html_root_url_updated"]
 
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds


### PR DESCRIPTION
Turning off the `assert_contains_regex!` macro removes deps on regex and regex-syntax.