### PR TITLE
Add GitHub Actions workflow to run markdown-link-check

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "img.shields.io"
+    },
+    {
+      "pattern": "^https://docs.rs/ruby-file-expand-path$"
     }
   ],
   "replacementPatterns": [],

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,32 @@
+---
+"on":
+  push:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  pull_request:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  schedule:
+    - cron: "0 0 * * TUE"
+name: Markdown Links Check
+jobs:
+  check-links:
+    name: Check links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        # checks all markdown files from /docs including all subfolders
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          config-file: ".github/markdown-link-check.json"
+          folder-path: "."


### PR DESCRIPTION
Artichoke already incorporates this tool in the `Rakefile` as the
`release:markdown_link_check` task, but it is slow and doesn't get
regularly run.

Incorporate this into CI such that links are checked on every PR that
touches markdown files and on a weekly cron with the same cadence as the
audit workflow.

Ignore docs.rs link since ruby-file-expand-path is not yet published to crates.io.