### PR TITLE
Remove target limits from package.metadata.docs.rs, add doc_cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,4 @@ default-features = false
 features = ["markdown_deps_updated", "html_root_url_updated"]
 
 [package.metadata.docs.rs]
-# This sets the default target to `x86_64-unknown-linux-gnu` and only builds
-# that target. `boba` has the same API and code on all targets.
-targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,12 @@
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
+
+//! WIP
+
 #![doc(html_root_url = "https://docs.rs/ruby-file-expand-path/0.1.0")]
 
 #[cfg(test)]


### PR DESCRIPTION
`ruby-file-expand-path` _does_ have different code on different targets, so don't limit the docs.rs targets to Linux.