### PR TITLE
Remove dependency on actions-rs organization GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: stable
-          profile: minimal
 
       - name: Compile
         run: cargo build --verbose
@@ -57,16 +56,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/check-minimal-versions@v1
         with:
-          toolchain: nightly
-          override: true
-          profile: minimal
+          toolchain: stable
+
+      - name: Generate minimal versions lockfile
+        run: cargo +nightly generate-lockfile -Z minimal-versions
 
       - name: Check with minimal versions
-        run: |
-          cargo generate-lockfile -Z minimal-versions
-          cargo check
+        run: cargo check --all-targets --profile=test
 
   rust:
     name: Lint and format Rust
@@ -79,21 +77,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/lint-and-format@v1
         with:
-          toolchain: nightly
-          override: true
-          profile: minimal
-          components: rustfmt, clippy
+          toolchain: stable
 
       - name: Check formatting
-        run: cargo fmt -- --check --color=auto
+        run: cargo fmt --check
 
       - name: Lint with Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets
 
   ruby:
     name: Lint and format Ruby


### PR DESCRIPTION
These actions are unmaintained and use deprecated GitHub Actions technologies.

See: https://github.com/artichoke/project-infrastructure/issues/265

Also remove nightly requirement for lint and format build job.